### PR TITLE
パスワード再設定機能を追加

### DIFF
--- a/src/components/ModalForgetPassword.tsx
+++ b/src/components/ModalForgetPassword.tsx
@@ -34,6 +34,7 @@ const ModalForgetPassword: React.FC<AppProps> = ({
           <button
             onClick={() => {
               setOpenModalForgetPassword(false);
+              setResetPasswordEmail("");
             }}
           >
             閉じる

--- a/src/components/ModalForgetPassword.tsx
+++ b/src/components/ModalForgetPassword.tsx
@@ -1,0 +1,70 @@
+interface AppProps {
+  setOpenModalForgetPassword: (x: boolean) => void;
+  resetPasswordEmail: string;
+  setResetPasswordEmail: (x: string) => void;
+  onClickResetPasswordSubmit: (
+    e: React.FormEvent<HTMLButtonElement>
+  ) => Promise<void>;
+}
+
+const ModalForgetPassword: React.FC<AppProps> = ({
+  setOpenModalForgetPassword,
+  resetPasswordEmail,
+  setResetPasswordEmail,
+  onClickResetPasswordSubmit,
+}) => {
+  return (
+    <>
+      <div className="modal">
+        <div className="inner">
+          <h1>パスワードの再設定</h1>
+          <form>
+            <input
+              type="email"
+              id="email"
+              name="email"
+              value={resetPasswordEmail}
+              placeholder="メールアドレス"
+              onChange={(e) => setResetPasswordEmail(e.target.value)}
+            />
+            <button type="submit" onClick={onClickResetPasswordSubmit}>
+              OK
+            </button>
+          </form>
+          <button
+            onClick={() => {
+              setOpenModalForgetPassword(false);
+            }}
+          >
+            閉じる
+          </button>
+        </div>
+      </div>
+      <style jsx>{`
+        .modal {
+          z-index: 4;
+          position: fixed;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+          background-color: rgba(0, 0, 0, 0.5);
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        }
+        .inner {
+          background-color: #fffffe;
+          width: calc(772 / 1920 * 100vw);
+          height: calc(580 / 1920 * 100vw);
+          border-radius: calc(65 / 1920 * 100vw);
+          display: flex;
+          flex-direction: column;
+          padding: calc(57.5 / 1920 * 100vw) calc(70.5 / 1920 * 100vw);
+        }
+      `}</style>
+    </>
+  );
+};
+
+export default ModalForgetPassword;

--- a/src/pages/jumps/Login.tsx
+++ b/src/pages/jumps/Login.tsx
@@ -2,10 +2,33 @@ import { useState } from "react";
 import { firebase } from "../../../config/firebase";
 import { Button } from "antd";
 import Link from "next/Link";
+import ModalForgetPassword from "../../components/ModalForgetPassword";
 
 const Login: React.FC<{}> = () => {
   const [email, setEmail] = useState<string>("");
   const [password, setPassword] = useState<string>("");
+  const [openModalForgetPassword, setOpenModalForgetPassword] =
+    useState<boolean>(false);
+  const [resetPasswordEmail, setResetPasswordEmail] = useState("");
+
+  //パスワード再設定
+  const onClickResetPasswordSubmit = async (
+    e: React.FormEvent<HTMLButtonElement>
+  ): Promise<void> => {
+    e.preventDefault();
+    const result = await firebase
+      .auth()
+      .sendPasswordResetEmail(resetPasswordEmail)
+      .then(() => {
+        setOpenModalForgetPassword(false);
+        return "入力されたメールアドレスにパスワード再設定のご案内をお送りしました";
+      })
+      .catch(() => {
+        setResetPasswordEmail("");
+        return "存在しないメールアドレスです";
+      });
+    alert(result);
+  };
 
   //メールアドレスでログイン
   const handleSubmit = async (
@@ -59,6 +82,14 @@ const Login: React.FC<{}> = () => {
 
   return (
     <>
+      {openModalForgetPassword && (
+        <ModalForgetPassword
+          setOpenModalForgetPassword={setOpenModalForgetPassword}
+          resetPasswordEmail={resetPasswordEmail}
+          setResetPasswordEmail={setResetPasswordEmail}
+          onClickResetPasswordSubmit={onClickResetPasswordSubmit}
+        />
+      )}
       <h1>Loginページ</h1>
       <div>
         <form onSubmit={handleSubmit}>
@@ -85,6 +116,13 @@ const Login: React.FC<{}> = () => {
           </div>
           <button type="submit">メールアドレスでログイン</button>
         </form>
+        <button
+          onClick={(): void => {
+            setOpenModalForgetPassword(true);
+          }}
+        >
+          パスワードを忘れましたか？
+        </button>
       </div>
       <div>
         <Button type="primary" onClick={onClickGoogle}>

--- a/src/pages/jumps/Login.tsx
+++ b/src/pages/jumps/Login.tsx
@@ -20,6 +20,7 @@ const Login: React.FC<{}> = () => {
       .auth()
       .sendPasswordResetEmail(resetPasswordEmail)
       .then(() => {
+        setResetPasswordEmail("");
         setOpenModalForgetPassword(false);
         return "入力されたメールアドレスにパスワード再設定のご案内をお送りしました";
       })


### PR DESCRIPTION
## Issue

Closes #17

## 今回の PR で行ったこと

- パスワード再設定機能を追加
- モーダルウィンドウ上で処理を行うように変更
- 再設定メール送信成功、失敗、モーダルウィンドウを閉じた際に入力したメールアドレスをリセットする機能を追加
- firebaseの再設定メールの文面を変更

## 動作確認(どのような動作確認を行ったのか？ 結果はどうか？)

- alertで成功と失敗の表示が出ることを確認
- 実際にメールを送信し、受信したことを確認
- 一度閉じた際や、送信後にメールアドレス入力欄がリセットされていることを確認

## 影響範囲(行った作業によってどこまで影響が及ぶようになるか)

- login.tsx

## 備考

- スタイルはstyled JSXを使用し、仮で付けています。（モーダルウィンドウにするため）